### PR TITLE
Add prefix option

### DIFF
--- a/addon/components/pdf-view.js
+++ b/addon/components/pdf-view.js
@@ -10,7 +10,12 @@ export default Component.extend({
   filePath: '/ember-pdfjs-wrapper/pdfjs/web/compressed.tracemonkey-pldi-09.pdf',
   src: computed('filepath', {
     get(key) {
-      return `/ember-pdfjs-wrapper/pdfjs/web/viewer.html?file=${this.filePath}`;
+      if (this.prefix) {
+        return `${this.prefix}/ember-pdfjs-wrapper/pdfjs/web/viewer.html?file=${this.filePath}`;
+
+      } else {
+        return `/ember-pdfjs-wrapper/pdfjs/web/viewer.html?file=${this.filePath}`;
+      }
     },
     set(key, value) {
       return value;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6929,7 +6929,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7344,7 +7345,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7400,6 +7402,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7443,12 +7446,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
In some apps, we have a rootUrl that is prefixing all the routes of the app. When this is the case, this addon breaks because it is missing this prefix. This PR gives the user a chance to give one.